### PR TITLE
Add cstdint include to attFile.h

### DIFF
--- a/src/fileformats/attFile.h
+++ b/src/fileformats/attFile.h
@@ -22,6 +22,7 @@
 #include <array>
 #include <iosfwd>
 #include <vector>
+#include <cstdint>
 
 class attFile {
   public:


### PR DESCRIPTION
To fix missing `uint8_t` type error on Ubuntu 22.04 LTS (Jammy Jellyfish)