### PR TITLE
Add changes needed to build and use clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 out/
 .vs/
+.cache/
 
 # Misc debris
 .*.sw?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.3)
 project(openc2e)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(SRC "${CMAKE_CURRENT_SOURCE_DIR}")
 set(BIN "${CMAKE_CURRENT_BINARY_DIR}")
 set(GEN "${BIN}/generated")

--- a/src/common/encoding.h
+++ b/src/common/encoding.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/common/readfile.h
+++ b/src/common/readfile.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <vector>

--- a/src/fileformats/PrayFileReader.h
+++ b/src/fileformats/PrayFileReader.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <string>

--- a/src/openc2e/Catalogue.h
+++ b/src/openc2e/Catalogue.h
@@ -21,6 +21,7 @@
 
 #include "common/Exception.h"
 
+#include <cstdint>
 #include <ghc/filesystem.hpp>
 #include <iostream>
 #include <istream>

--- a/src/openc2e/SFCFile.h
+++ b/src/openc2e/SFCFile.h
@@ -20,6 +20,7 @@
 #ifndef _SFCFILE_H
 #define _SFCFILE_H
 
+#include <cstdint>
 #include <istream>
 #include <map>
 #include <string>

--- a/src/openc2e/VoiceData.h
+++ b/src/openc2e/VoiceData.h
@@ -20,6 +20,7 @@
 #ifndef _VOICEDATA_H
 #define _VOICEDATA_H
 
+#include <cstdint>
 #include <istream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
I needed to add these changes to get `clangd` intellisense to work in vscode, and to get the project to build with `c++ (GCC) 13.2.1 20230801` - not sure if they're needed for `clang`?