### PR TITLE
Fix out of bound read in CaosLexer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ target_link_libraries(openc2e-fileformats
 )
 
 add_executable(test_fileformats
+	src/fileformats/tests/CaosLexerTest.cpp
 	src/fileformats/tests/CatalogueFileTest.cpp
 	src/fileformats/tests/CfgFileTest.cpp
 	src/fileformats/tests/MngTest.cpp

--- a/src/fileformats/caoslexer.cpp
+++ b/src/fileformats/caoslexer.cpp
@@ -184,7 +184,6 @@ start:
 str:
 	if (p[0] == '\0') {
 		push_value(caostoken::TOK_ERROR);
-		goto eoi;
 	} else if (p[0] == '\r' || p[0] == '\n') {
 		p++;
 		push_value(caostoken::TOK_ERROR);

--- a/src/fileformats/caoslexer.cpp
+++ b/src/fileformats/caoslexer.cpp
@@ -182,7 +182,10 @@ start:
 	}
 
 str:
-	if (p[0] == '\0' || p[0] == '\r' || p[0] == '\n') {
+	if (p[0] == '\0') {
+		push_value(caostoken::TOK_ERROR);
+		goto eoi;
+	} else if (p[0] == '\r' || p[0] == '\n') {
 		p++;
 		push_value(caostoken::TOK_ERROR);
 	} else if (p[0] == '\\') {

--- a/src/fileformats/tests/CaosLexerTest.cpp
+++ b/src/fileformats/tests/CaosLexerTest.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include "fileformats/caoslexer.h"
+#include "fileformats/caostoken.h"
+
+#include <fmt/format.h>
+#include <string>
+#include <vector>
+
+std::string debug_repr(const std::string &s) {
+    std::string out;
+    for (auto c : s) {
+        if (c == '\n') {
+            out += "\\n";
+        } else if (c == '\r') {
+            out += "\\r";
+        } else if (c == '\t') {
+            out += "\\t";
+        } else if (c == '\\') {
+            out += "\\\\";
+        } else if (c < 0x20 || c >= 0x7f) {
+            out += fmt::format("\\x{:x}", static_cast<uint8_t>(c));
+        } else {
+            out += c;
+        }
+    }
+    return out;
+}
+
+std::string format_token_list(const std::vector<caostoken>& token) {
+    std::string out;
+    for (const auto& t : token) {
+        out += t.typeAsString() + " " +  debug_repr(t.format()) +
+                  " line:" + std::to_string(t.lineno) + "\n";
+    }
+    return out;
+}
+
+TEST(lexcaos, unterminated_double_quote) {
+    std::vector<caostoken> tokens;
+    lexcaos(tokens, "\"");
+
+    std::vector<caostoken> expected{
+        {caostoken::TOK_ERROR, 1},
+        {caostoken::TOK_EOI, "\0", 1},
+    };
+
+    ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}

--- a/src/fileformats/tests/CaosLexerTest.cpp
+++ b/src/fileformats/tests/CaosLexerTest.cpp
@@ -1,49 +1,28 @@
-#include <gtest/gtest.h>
-
 #include "fileformats/caoslexer.h"
+
 #include "fileformats/caostoken.h"
 
 #include <fmt/format.h>
+#include <gtest/gtest.h>
 #include <string>
 #include <vector>
 
-std::string debug_repr(const std::string &s) {
-    std::string out;
-    for (auto c : s) {
-        if (c == '\n') {
-            out += "\\n";
-        } else if (c == '\r') {
-            out += "\\r";
-        } else if (c == '\t') {
-            out += "\\t";
-        } else if (c == '\\') {
-            out += "\\\\";
-        } else if (c < 0x20 || c >= 0x7f) {
-            out += fmt::format("\\x{:x}", static_cast<uint8_t>(c));
-        } else {
-            out += c;
-        }
-    }
-    return out;
-}
-
 std::string format_token_list(const std::vector<caostoken>& token) {
-    std::string out;
-    for (const auto& t : token) {
-        out += t.typeAsString() + " " +  debug_repr(t.format()) +
-                  " line:" + std::to_string(t.lineno) + "\n";
-    }
-    return out;
+	std::string out;
+	for (const auto& t : token) {
+		out += fmt::format("{} {:?} line:{}\n", t.typeAsString(), t.format(), t.lineno);
+	}
+	return out;
 }
 
 TEST(lexcaos, unterminated_double_quote) {
-    std::vector<caostoken> tokens;
-    lexcaos(tokens, "\"");
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "\"");
 
-    std::vector<caostoken> expected{
-        {caostoken::TOK_ERROR, 1},
-        {caostoken::TOK_EOI, "\0", 1},
-    };
+	std::vector<caostoken> expected{
+		{caostoken::TOK_ERROR, 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
 
-    ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
 }


### PR DESCRIPTION
I noticed that the CaosLexer has some bugs where it reads beyond the null termination character for malformed input. This can cause a read into unallocated memory, which can potentially cause the code to crash.

There's a security concern here, as malicious input can cause the lexer to read uninitialized memory (similar to [Heartbleed](https://en.wikipedia.org/wiki/Heartbleed)), though it's only a single byte, and it's hard to imagine an attacker weaponizing this in the context of openc2e.

This change does a few things:

1. Adds a unit test to exercise the previously vulnerable code path. You can't see the failure since the fix is also in this PR, but you can see what happens without the fix [in this build on my copy of the repo](https://github.com/mtlynch/openc2e/actions/runs/11849613968/job/33023157739)
1. Fixes the vulnerability by gracefully handling the null terminator following a double quote character