### PR TITLE
Print clang-format version during CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/checkout@v3
     - name: "Download clang-format"
       run: "wget -o- https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-22538c65/clang-format-10_linux-amd64 && chmod +x clang-format-10_linux-amd64"
+    - name: "Print clang-format version"
+      run: "./clang-format-10_linux-amd64 --version"
     - name: "clang-format"
       run: "./clang-format-10_linux-amd64 -i src/**/*.cpp src/**/*.h && git diff --exit-code"
       


### PR DESCRIPTION
For tools that are highly-sensitive to exact versions, I find it helpful to have the exact version in the build logs to know how to reproduce the CI steps locally.

I realize there's a 10 in the binary name, but I actually didn't realize that was the version. But beyond that, I think having the exact version is helpful and has no real downside.