### PR TITLE
Print version of clang-format during lint.py

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -32,14 +32,17 @@ if shutil.which(f"clang-format-{REQUIRED_CLANG_FORMAT_MAJOR}"):
     clang_format = f"clang-format-{REQUIRED_CLANG_FORMAT_MAJOR}"
 elif shutil.which("clang-format"):
     clang_format = "clang-format"
-    clang_format_version = run(clang_format, "--version").rstrip().split(" ")[2]
-    clang_format_major = int(clang_format_version.split(".")[0])
-    if clang_format_major != REQUIRED_CLANG_FORMAT_MAJOR:
-        eprint(f"warning: clang-format is wrong version (wanted {REQUIRED_CLANG_FORMAT_MAJOR}, got {clang_format_version})")
 else:
     eprint("error: clang-format is not installed.")
     eprint(f"Install clang-format version {REQUIRED_CLANG_FORMAT_MAJOR}")
     exit(1)
+
+clang_format_version = run(clang_format, "--version").rstrip().split(" ")[2]
+clang_format_major = int(clang_format_version.split(".")[0])
+if verbose:
+    eprint(f"using {clang_format} version {clang_format_version}")
+if clang_format_major != REQUIRED_CLANG_FORMAT_MAJOR:
+    eprint(f"warning: clang-format is wrong version (wanted {REQUIRED_CLANG_FORMAT_MAJOR}, got {clang_format_version})")
 
 since_rev = sys.argv[1] if len(sys.argv) > 1 else "HEAD"
 os.chdir(run("git", "rev-parse", "--show-toplevel").rstrip())


### PR DESCRIPTION
Update scripts/lint.py to print out the exact version of clang-format that ran when executing the lint script.

Related: https://github.com/openc2e/openc2e/pull/216

This also introduces a slight behavioral change. Previously, we assumed that if `clang-format-10` existed in the user's PATH, then they had the correct version of `clang-format` installed and we didn't call `clang-format --version` to verify the major version. After this change, we unconditionally call `clang-format --version` and check the major version number, even if the binary is called `clang-format-10`.