### PR TITLE
Fix glob matching in lint CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
     - name: "Download clang-format"
       run: "wget -o- https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-22538c65/clang-format-10_linux-amd64 && chmod +x clang-format-10_linux-amd64"
     - name: "clang-format"
-      run: "./clang-format-10_linux-amd64 -i src/**/*.cpp src/**/*.h && git diff --exit-code"
-      
+      run: "shopt -s globstar; ./clang-format-10_linux-amd64 -i src/**/*.cpp src/**/*.h && git diff --exit-code"
+
   build:
     name: build-${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
bash doesn't support recursive globbing by default, so `src/**/*.cpp` is equivalent to `src/*/*.cpp`, which searches directories exactly one level below `src/`. This is why the lint CI step missed the formatting error in https://github.com/openc2e/openc2e/pull/215, as the misformatted file was two directory levels below `src/`.

To achieve the intended recursive glob matching behavior, we can enable the bash [globstar option](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#The-Shopt-Builtin-1).