### PR TITLE
Fix out of bound read in CaosLexer - unterminated single quote

### DIFF
--- a/src/fileformats/caoslexer.cpp
+++ b/src/fileformats/caoslexer.cpp
@@ -135,7 +135,9 @@ start:
 			push_value(caostoken::TOK_ERROR);
 		}
 		p++; // the actual char
-		if (p[0] != '\'') {
+		if (p[0] == '\0') {
+			push_value(caostoken::TOK_ERROR);
+		} else if (p[0] != '\'') {
 			p++;
 			push_value(caostoken::TOK_ERROR);
 		}

--- a/src/fileformats/tests/CaosLexerTest.cpp
+++ b/src/fileformats/tests/CaosLexerTest.cpp
@@ -15,6 +15,30 @@ std::string format_token_list(const std::vector<caostoken>& token) {
 	return out;
 }
 
+TEST(lexcaos, unterminated_single_quote) {
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "'");
+
+	std::vector<caostoken> expected{
+		{caostoken::TOK_ERROR, 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
+
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}
+
+TEST(lexcaos, unterminated_single_quote_letter) {
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "'a");
+
+	std::vector<caostoken> expected{
+		{caostoken::TOK_ERROR, 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
+
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}
+
 TEST(lexcaos, unterminated_double_quote) {
 	std::vector<caostoken> tokens;
 	lexcaos(tokens, "\"");


### PR DESCRIPTION
This fixes a bug in the CAOS lexer where it accidentally reads beyond the null termination character for a malformed CAOS input.

Specifically, if CAOS has a quoted character literal like 'a, but the input ends before the terminating single quote, the lexer gets confused and reads beyond the buffer.

This fixes the lexer bug and adds unit tests to exercise the fix.