### PR TITLE
Fix out of bound read in CaosLexer - unterminated byte string

### DIFF
--- a/src/fileformats/caoslexer.cpp
+++ b/src/fileformats/caoslexer.cpp
@@ -201,9 +201,10 @@ str:
 	}
 
 bytestr:
-	if (p[0] == '\0' || p[0] == '\r' || p[0] == '\n') {
-		p++;
+	if (p[0] == '\0') {
 		push_value(caostoken::TOK_ERROR);
+	} else if (p[0] == '\r' || p[0] == '\n') {
+		p++;
 	} else if (p[0] == ']') {
 		p++;
 		push_value(caostoken::TOK_BYTESTR);

--- a/src/fileformats/tests/CaosLexerTest.cpp
+++ b/src/fileformats/tests/CaosLexerTest.cpp
@@ -50,3 +50,15 @@ TEST(lexcaos, unterminated_double_quote) {
 
 	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
 }
+
+TEST(lexcaos, unterminated_byte_string) {
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "[");
+
+	std::vector<caostoken> expected{
+		{caostoken::TOK_ERROR, 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
+
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}


### PR DESCRIPTION
This fixes a bug in the CAOS lexer where it accidentally reads beyond the null termination character for a malformed CAOS input.

Specifically, if CAOS has an unterminated byte string like `[`, but the input ends before any characters, the lexer gets confused and reads beyond the buffer.

This fixes the lexer bug and adds a unit test to exercise the fix.