### PR TITLE
Fix out of bound reads and line numbers in CaosLexer for byte strings

### DIFF
--- a/src/fileformats/caoslexer.cpp
+++ b/src/fileformats/caoslexer.cpp
@@ -205,6 +205,8 @@ bytestr:
 		push_value(caostoken::TOK_ERROR);
 	} else if (p[0] == '\r' || p[0] == '\n') {
 		p++;
+		yylineno++;
+		push_value(caostoken::TOK_ERROR);
 	} else if (p[0] == ']') {
 		p++;
 		push_value(caostoken::TOK_BYTESTR);

--- a/src/fileformats/caoslexer.cpp
+++ b/src/fileformats/caoslexer.cpp
@@ -201,9 +201,10 @@ str:
 	}
 
 bytestr:
-	if (p[0] == '\0' || p[0] == '\r' || p[0] == '\n') {
-		p++;
+	if (p[0] == '\0') {
 		push_value(caostoken::TOK_ERROR);
+	} else if (p[0] == '\r' || p[0] == '\n') {
+		p++;
 	} else if (p[0] == ']') {
 		p++;
 		push_value(caostoken::TOK_BYTESTR);

--- a/src/fileformats/tests/CaosLexerTest.cpp
+++ b/src/fileformats/tests/CaosLexerTest.cpp
@@ -50,3 +50,55 @@ TEST(lexcaos, unterminated_double_quote) {
 
 	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
 }
+
+TEST(lexcaos, byte_string_single_character) {
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "[0]");
+
+	std::vector<caostoken> expected{
+		{caostoken::TOK_BYTESTR, "[0]", 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
+
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}
+
+TEST(lexcaos, byte_string_multiple_characters) {
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "[0123]");
+
+	std::vector<caostoken> expected{
+		{caostoken::TOK_BYTESTR, "[0123]", 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
+
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}
+
+TEST(lexcaos, byte_string_with_newline) {
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "[01\n02]");
+
+	std::vector<caostoken> expected{
+		{caostoken::TOK_ERROR, "[01\n", 1},
+		{caostoken::TOK_INT, "02", 1},
+		{caostoken::TOK_ERROR, "]", 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
+
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}
+
+TEST(lexcaos, byte_string_with_carriage_return) {
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "[01\r02]");
+
+	std::vector<caostoken> expected{
+		{caostoken::TOK_ERROR, "[01\r", 1},
+		{caostoken::TOK_INT, "02", 1},
+		{caostoken::TOK_ERROR, "]", 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
+
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}

--- a/src/fileformats/tests/CaosLexerTest.cpp
+++ b/src/fileformats/tests/CaosLexerTest.cpp
@@ -51,6 +51,18 @@ TEST(lexcaos, unterminated_double_quote) {
 	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
 }
 
+TEST(lexcaos, unterminated_byte_string) {
+	std::vector<caostoken> tokens;
+	lexcaos(tokens, "[");
+
+	std::vector<caostoken> expected{
+		{caostoken::TOK_ERROR, 1},
+		{caostoken::TOK_EOI, "\0", 1},
+	};
+
+	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
+}
+
 TEST(lexcaos, byte_string_single_character) {
 	std::vector<caostoken> tokens;
 	lexcaos(tokens, "[0]");

--- a/src/fileformats/tests/CaosLexerTest.cpp
+++ b/src/fileformats/tests/CaosLexerTest.cpp
@@ -56,7 +56,7 @@ TEST(lexcaos, unterminated_byte_string) {
 	lexcaos(tokens, "[");
 
 	std::vector<caostoken> expected{
-		{caostoken::TOK_ERROR, 1},
+		{caostoken::TOK_ERROR, "[", 1},
 		{caostoken::TOK_EOI, "\0", 1},
 	};
 
@@ -93,9 +93,9 @@ TEST(lexcaos, byte_string_with_newline) {
 
 	std::vector<caostoken> expected{
 		{caostoken::TOK_ERROR, "[01\n", 1},
-		{caostoken::TOK_INT, "02", 1},
-		{caostoken::TOK_ERROR, "]", 1},
-		{caostoken::TOK_EOI, "\0", 1},
+		{caostoken::TOK_INT, "02", 2},
+		{caostoken::TOK_ERROR, "]", 2},
+		{caostoken::TOK_EOI, "\0", 2},
 	};
 
 	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));
@@ -107,9 +107,9 @@ TEST(lexcaos, byte_string_with_carriage_return) {
 
 	std::vector<caostoken> expected{
 		{caostoken::TOK_ERROR, "[01\r", 1},
-		{caostoken::TOK_INT, "02", 1},
-		{caostoken::TOK_ERROR, "]", 1},
-		{caostoken::TOK_EOI, "\0", 1},
+		{caostoken::TOK_INT, "02", 2},
+		{caostoken::TOK_ERROR, "]", 2},
+		{caostoken::TOK_EOI, "\0", 2},
 	};
 
 	ASSERT_EQ(format_token_list(tokens), format_token_list(expected));


### PR DESCRIPTION
This includes three changes:

1. Add unit tests for how the lexer currently handles byte string tokens
2. Fix a bug in the lexer that caused it to read beyond the input buffer's allocated memory
3. Adjust the lexer's behavior for seeing newlines in byte strings so that newlines cause it to increment the line number associated with subsequent tokens, even though the newline within the byte strings are an error

Note that the lexer will treat a Windows newline (`\r\n`) as two lines, but that's consistent with how it treats regular strings. We can fix that in a subsequent PR, but I want to avoid expanding the scope of this one.